### PR TITLE
Retire v1 commodities schema.

### DIFF
--- a/src/eddn/conf/Settings.py
+++ b/src/eddn/conf/Settings.py
@@ -38,11 +38,11 @@ class _Settings(object):
     GATEWAY_IP_KEY_SALT = None
 
     GATEWAY_JSON_SCHEMAS = {
-        "http://schemas.elite-markets.net/eddn/commodity/1": "schemas/commodity-v0.1.json",
-        "http://schemas.elite-markets.net/eddn/commodity/1/test": "schemas/commodity-v0.1.json",
+        "http://schemas.elite-markets.net/eddn/commodity/1"      : None,
+        "http://schemas.elite-markets.net/eddn/commodity/1/test" : None,
 
-        "http://schemas.elite-markets.net/eddn/commodity/2": "schemas/commodity-v2.0.json",
-        "http://schemas.elite-markets.net/eddn/commodity/2/test": "schemas/commodity-v2.0.json"
+        "http://schemas.elite-markets.net/eddn/commodity/2"      : "schemas/commodity-v2.0.json",
+        "http://schemas.elite-markets.net/eddn/commodity/2/test" : "schemas/commodity-v2.0.json"
     }
 
     ###############################################################################


### PR DESCRIPTION
This is a fairly simple implementation for review.

I've done limited testing with some older clients:

- E:D Market Connector < 1.40 will say "426 Client Error: Upgrade Required"
- edce-client 1.0.6 will say "EDCE: Error: EDDN postMarketData FAIL submit error"
- EliteOCR 0.6.x will popup a message box saying "Following entries could not be exported: Clothing, Grain, Hydrogen Fuel, Consumer Technology, Domestic Appliances, etc..."

I've used a new stats category of "retired" rather than "invalid". But I haven't updated the monitor to display this category.