### PR TITLE
Add reason text to reply for outdated schemas.

### DIFF
--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -132,7 +132,7 @@ def parse_and_error_handle(data):
 
     # Here we check if an outdated schema has been passed
     if parsed_message["$schemaRef"] in Settings.GATEWAY_OUTDATED_SCHEMAS.keys():
-        response.status = 426
+        response.status = '426 Upgrade Required'	# Bottle (and underlying httplib) don't know this one
         statsCollector.tally("outdated")
         return "FAIL: The schema you have used need an upgrade. Update your software."
 


### PR DESCRIPTION
Bottle (and httplib which supplies most of it's underlying HTTP functionality) doesn't have an appropriate response reason text for error 426, which means that it responds to clients with 426, "Unknown".
This patch changes that response to 426, "Upgrade Required".

(You'll be relieved to know that Bottle *does* have the correct response reason text for error 418, which is "I'm a teapot").
