### PR TITLE
Add E:D 1.4 ships.

### DIFF
--- a/schemas/shipyard-v1.0.json
+++ b/schemas/shipyard-v1.0.json
@@ -52,7 +52,7 @@
                     "items"         : {
                         "type"          : "string",
                         "minLength"     : 1,
-                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Dropship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Vulture"
+                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Assault Ship, Federal Dropship, Federal Gunship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Eagle, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Vulture"
                     }
                 }
             }


### PR DESCRIPTION
These aren't present in the released game yet, but to avoid variant spellings it's better to document standardised names before release. The in-game names are taken from [here](https://forums.frontier.co.uk/showthread.php?t=179092&page=2&p=2762161&viewfull=1#post2762161).

This is a documentation change only, so I haven't bumped the schema version number.
