### PR TITLE
Add E:D 1.5 ships.

### DIFF
--- a/schemas/shipyard-v1.0.json
+++ b/schemas/shipyard-v1.0.json
@@ -52,7 +52,7 @@
                     "items"         : {
                         "type"          : "string",
                         "minLength"     : 1,
-                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Assault Ship, Federal Dropship, Federal Gunship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Eagle, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Vulture"
+                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, Cobra MkIV, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Corvette, Federal Dropship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Cutter, Keelback, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Viper MkIV, Vulture"
                     }
                 }
             }

--- a/schemas/shipyard-v1.0.json
+++ b/schemas/shipyard-v1.0.json
@@ -52,7 +52,7 @@
                     "items"         : {
                         "type"          : "string",
                         "minLength"     : 1,
-                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, Cobra MkIV, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Corvette, Federal Dropship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Cutter, Keelback, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Viper MkIV, Vulture"
+                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, Cobra MkIV, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Assault Ship, Federal Corvette, Federal Dropship, Federal Gunship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Cutter, Imperial Eagle, Keelback, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Viper MkIV, Vulture"
                     }
                 }
             }

--- a/schemas/shipyard-v1.0.json
+++ b/schemas/shipyard-v1.0.json
@@ -52,7 +52,7 @@
                     "items"         : {
                         "type"          : "string",
                         "minLength"     : 1,
-                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Cobra Mk III, Cobra MkIV, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Assault Ship, Federal Corvette, Federal Dropship, Federal Gunship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Cutter, Imperial Eagle, Keelback, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Viper MkIV, Vulture"
+                        "description"   : "Ship name in English as displayed in-game. i.e. one of: Adder, Anaconda, Asp, Asp Scout, Cobra Mk III, Cobra MkIV, DiamondBack Scout, Diamondback Explorer, Eagle, Federal Assault Ship, Federal Corvette, Federal Dropship, Federal Gunship, Fer-de-Lance, Hauler, Imperial Clipper, Imperial Courier, Imperial Cutter, Imperial Eagle, Keelback, Orca, Python, Sidewinder, Type-6 Transporter, Type-7 Transporter, Type-9 Heavy, Viper, Viper MkIV, Vulture"
                     }
                 }
             }


### PR DESCRIPTION
Some ships have been [renamed](https://forums.frontier.co.uk/showthread.php?t=201194#post3113104) between E:D 1.4 and 1.5, i.e.:
- Asp - > Asp Explorer
- Cobra Mk III -> Cobra MkIII
- Viper -> Viper MkIII

This patch retains the old names for these ships to avoid disruption for consumers, while adding the new ships with the new naming scheme. i.e.:
- Asp Scout
- Cobra MkIV
- Viper MkIV

Note: This is a documentation change only, so I haven't bumped the schema version number.