### PR TITLE
Handle non-ASCII characters in messages, e.g. in the uploaderID field.

### DIFF
--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -150,7 +150,7 @@ def parse_and_error_handle(data):
 
         # Sends the parsed MarketOrderList or MarketHistoryList to the Announcers
         # as compressed JSON.
-        gevent.spawn(push_message, simplejson.dumps(parsed_message), parsed_message['$schemaRef'])
+        gevent.spawn(push_message, simplejson.dumps(parsed_message, ensure_ascii=False).encode('utf-8'), parsed_message['$schemaRef'])
         logger.info("Accepted %s upload from %s" % (
             parsed_message, get_remote_address()
         ))


### PR DESCRIPTION
The gateway mangles non-ASCII characters in messages - e.g. the uploaderID field in [this](https://ross.eddb.io/eddn/log/6392741) message. This fixes that.

(I've had a quick look at the other uses of json.dumps() in the gateway, relay and monitor and they all seem OK).
