### PR TITLE
Make gatewayTimestamp strictly conformant.

### DIFF
--- a/src/eddn/Gateway.py
+++ b/src/eddn/Gateway.py
@@ -139,7 +139,7 @@ def parse_and_error_handle(data):
     validationResults = validator.validate(parsed_message)
 
     if validationResults.severity <= ValidationSeverity.WARN:
-        parsed_message['header']['gatewayTimestamp'] = datetime.utcnow().isoformat()
+        parsed_message['header']['gatewayTimestamp'] = datetime.utcnow().isoformat() + 'Z'
 
         ip_hash_salt = Settings.GATEWAY_IP_KEY_SALT
         if ip_hash_salt:


### PR DESCRIPTION
Messages relayed by EDDN fail a strict validation (e.g. by http://jsonschemalint.com/draft4/) because gatewayTimestamp is not [RFC3339](http://tools.ietf.org/html/rfc3339#section-5.6) compliant as required by the JSON schema [spec](http://json-schema.org/latest/json-schema-validation.html#anchor108).

This fixes that.
