### PR TITLE
Schema for Journal entries

### DIFF
--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -1,0 +1,60 @@
+{
+    "$schema"               : "http://json-schema.org/draft-04/schema#",
+    "id"                    : "http://schemas.elite-markets.net/eddn/journal/1#",
+    "type"                  : "object",
+    "additionalProperties"  : false,
+    "required": [ "$schemaRef", "header", "message" ],
+    "properties": {
+        "$schemaRef": {
+            "type"                  : "string"
+        },
+        "header": {
+            "type"                  : "object",
+            "additionalProperties"  : true,
+            "required"              : [ "uploaderID", "softwareName", "softwareVersion" ],
+            "properties"            : {
+                "uploaderID": {
+                    "type"          : "string"
+                },
+                "softwareName": {
+                    "type"          : "string"
+                },
+                "softwareVersion": {
+                    "type"          : "string"
+                },
+                "gatewayTimestamp": {
+                    "type"          : "string",
+                    "format"        : "date-time",
+                    "description"   : "Timestamp upon receipt at the gateway. If present, this property will be overwritten by the gateway; submitters are not intended to populate this property."
+                }
+            }
+        },
+        "message": {
+            "type"                  : "object",
+            "description"           : "Contains all properties from the listed events in the client's journal minus Localised strings and the properties marked below as 'disallowed'",
+            "additionalProperties"  : true,
+            "required"              : [ "timestamp", "event" ],
+            "properties"            : {
+                "timestamp": {
+                    "type"          : "string",
+                    "format"        : "date-time"
+                },
+                "event" : {
+                    "enum"          : [ "Docked", "FSDJump", "Scan" ]
+                },
+
+                "CockpitBreach"     : { "$ref" : "#/definitions/disallowed" },
+                "BoostUsed"         : { "$ref" : "#/definitions/disallowed" },
+                "FuelLevel"         : { "$ref" : "#/definitions/disallowed" },
+                "FuelUsed"          : { "$ref" : "#/definitions/disallowed" },
+                "JumpDist"          : { "$ref" : "#/definitions/disallowed" }
+            },
+            "patternProperties"     : {
+                "_Localised$"       : { "$ref" : "#/definitions/disallowed" }
+            }
+        }
+    },
+    "definitions": {
+        "disallowed" : { "not" : { "type": [ "array", "boolean", "integer", "number", "null", "object", "string" ] } }
+    }
+}

--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -33,7 +33,7 @@
             "type"                  : "object",
             "description"           : "Contains all properties from the listed events in the client's journal minus Localised strings and the properties marked below as 'disallowed'",
             "additionalProperties"  : true,
-            "required"              : [ "timestamp", "event" ],
+            "required"              : [ "timestamp", "event", "StarSystem" ],
             "properties"            : {
                 "timestamp": {
                     "type"          : "string",
@@ -41,6 +41,11 @@
                 },
                 "event" : {
                     "enum"          : [ "Docked", "FSDJump", "Scan" ]
+                },
+                "StarSystem": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "Must be added by the sender if not present in the journal event"
                 },
 
                 "CockpitBreach"     : { "$ref" : "#/definitions/disallowed" },

--- a/src/eddn/conf/Settings.py
+++ b/src/eddn/conf/Settings.py
@@ -53,6 +53,9 @@ class _Settings(object):
         "http://schemas.elite-markets.net/eddn/outfitting/1/test": "schemas/outfitting-v1.0.json",
         "http://schemas.elite-markets.net/eddn/outfitting/2": "schemas/outfitting-v2.0.json",
         "http://schemas.elite-markets.net/eddn/outfitting/2/test": "schemas/outfitting-v2.0.json",
+
+        "http://schemas.elite-markets.net/eddn/journal/1": "schemas/journal-v1.0.json",
+        "http://schemas.elite-markets.net/eddn/journal/1/test": "schemas/journal-v1.0.json",
     }
 
     GATEWAY_OUTDATED_SCHEMAS = [


### PR DESCRIPTION
This schema allows clients to forward interesting entries from the "Commander's Log" Journal to EDDN - i.e. "Docked", "FSDJump" and "Scan" entries. The schema is based on [pre-release info](https://forums.frontier.co.uk/showthread.php/275151-Commanders-log-manual-and-data-sample/page14?p=4276171&viewfull=1#post4276171) so this PR will likely need to be updated during the E:D 2.2 beta run.

About the schema:
- The schema is deliberately minimal - it doesn't try to describe the *content* of the journal entries. Clients are expected to pass the Journal entries through essentially unmodified (but see the following points). 
- Some properties from the "Docked" and "FSDJump" Journal entries have been marked as "disallowed" since they're specific to the Cmdr. The sender must strip these properties out of the journal entries before transmitting them over EDDN.
- The various *_Localised properties have been marked as "disallowed" since they're redundant. The sender must also strip these properties out of the journal entries before transmitting them over EDDN.
- ~~The "Scan" journal entry contains a "BodyName" property like "Praea Euq NW-W b1-3 3 a", but no "StarSystem" property. Can listeners in all cases unambiguously split the "BodyName" into its system and body constituent parts?~~ The sender must track the current system and add a "StarSystem" property to those Journal entries that lack it (i.e. "Scan" entries).

[Here](https://gist.github.com/Marginal/a1d6fd6d88313034ff5d5ddc5a997f51) are some example messages in this schema.