### PR TITLE
Schema for Blackmarket info

### DIFF
--- a/schemas/blackmarket-v1.0.json
+++ b/schemas/blackmarket-v1.0.json
@@ -1,0 +1,66 @@
+{
+    "$schema"               : "http://json-schema.org/draft-04/schema#",
+    "id"                    : "http://schemas.elite-markets.net/eddn/blackmarket/1#",
+    "type"                  : "object",
+    "additionalProperties"  : false,
+    "required": [ "$schemaRef", "header", "message" ],
+    "properties": {
+        "$schemaRef": {
+            "type"                  : "string"
+        },
+        "header": {
+            "type"                  : "object",
+            "additionalProperties"  : true,
+            "required"              : [ "uploaderID", "softwareName", "softwareVersion" ],
+            "properties"            : {
+                "uploaderID": {
+                    "type"          : "string"
+                },
+                "softwareName": {
+                    "type"          : "string"
+                },
+                "softwareVersion": {
+                    "type"          : "string"
+                },
+                "gatewayTimestamp": {
+                    "type"          : "string",
+                    "format"        : "date-time",
+                    "description"   : "Timestamp upon receipt at the gateway. If present, this property will be overwritten by the gateway; submitters are not intended to populate this property."
+                }
+            }
+        },
+        "message": {
+            "type"                  : "object",
+            "description"           : "Contains all properties from the listed events in the client's journal minus Localised strings and the properties marked below as 'disallowed'",
+            "additionalProperties"  : true,
+            "required"              : [ "systemName", "stationName", "timestamp", "name", "sellPrice", "prohibited" ],
+            "properties"            : {
+                "systemName": {
+                    "type"          : "string",
+                    "minLength"     : 1
+                },
+                "stationName": {
+                    "type"          : "string",
+                    "minLength"     : 1
+                },
+                "timestamp": {
+                    "type"          : "string",
+                    "format"        : "date-time"
+                },
+                "name": {
+                    "type"          : "string",
+                    "minLength"     : 1,
+                    "description"   : "Commodity name as returned by the MarketSell entry in the Journal"
+                },
+                "sellPrice": {
+                    "type"          : "integer",
+                    "description"   : "Price to sell to the market"
+                },
+                "prohibited": {
+                    "type"          : "boolean",
+                    "description"   : "Whether the commodity is prohibited at this station"
+                }
+            }
+        }
+    }
+}

--- a/src/eddn/conf/Settings.py
+++ b/src/eddn/conf/Settings.py
@@ -53,6 +53,9 @@ class _Settings(object):
         "http://schemas.elite-markets.net/eddn/outfitting/1/test": "schemas/outfitting-v1.0.json",
         "http://schemas.elite-markets.net/eddn/outfitting/2": "schemas/outfitting-v2.0.json",
         "http://schemas.elite-markets.net/eddn/outfitting/2/test": "schemas/outfitting-v2.0.json",
+
+        "http://schemas.elite-markets.net/eddn/blackmarket/1": "schemas/blackmarket-v1.0.json",
+        "http://schemas.elite-markets.net/eddn/blackmarket/1/test": "schemas/blackmarket-v1.0.json",
     }
 
     GATEWAY_OUTDATED_SCHEMAS = [


### PR DESCRIPTION
This schema allows clients to send Black Market info derived from "MarketSell" entries in the "Commander's Log" Journal to EDDN. The schema is based on [pre-release info](https://forums.frontier.co.uk/showthread.php/275151-Commanders-log-manual-and-data-sample/page14?p=4276171&viewfull=1#post4276171) so this PR will likely need to be updated during the E:D 2.2 beta run.

The schema is loosely based on the commodity/3 schema, but note that values of the "name" property are different between commodity/3 and blackmarket/1 messages - e.g. "Mineral Oil" v "mineraloil".

[Here](https://gist.github.com/Marginal/d6116d46c37f090e38361f21457041bb) is an example message in this schema.