### PR TITLE
Add mandatory "StarPos" property.

### DIFF
--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -33,7 +33,7 @@
             "type"                  : "object",
             "description"           : "Contains all properties from the listed events in the client's journal minus Localised strings and the properties marked below as 'disallowed'",
             "additionalProperties"  : true,
-            "required"              : [ "timestamp", "event", "StarSystem" ],
+            "required"              : [ "timestamp", "event", "StarSystem", "StarPos" ],
             "properties"            : {
                 "timestamp": {
                     "type"          : "string",
@@ -45,6 +45,13 @@
                 "StarSystem": {
                     "type"          : "string",
                     "minLength"     : 1,
+                    "description"   : "Must be added by the sender if not present in the journal event"
+                },
+                "StarPos": {
+                    "type"          : "array",
+                    "items"         : { "type": "number" },
+                    "minItems"      : 3,
+                    "maxItems"      : 3,
                     "description"   : "Must be added by the sender if not present in the journal event"
                 },
 


### PR DESCRIPTION
The "Scan" entry in the E:D journal file lacks any System info.
Senders were made responsible for adding a "StarSystem" property in 335ec09.
This PR makes senders also responsible for adding a "StarPos" property, so that listeners can disambiguate messages about a System with a duplicate name.
